### PR TITLE
Ollama Flexibility

### DIFF
--- a/cmd/transcribe/main.go
+++ b/cmd/transcribe/main.go
@@ -114,7 +114,7 @@ func main() {
 
 	ollamaClient, err := ollama.NewOllamaClient(&url.URL{Scheme: c.OllamaProtocol, Host: c.OllamaHost}, &http.Client{
 		Timeout: 30 * time.Second,
-	})
+	}, c.OllamaModel)
 	if err != nil {
 		slog.Error("could not create ollama client", slog.String("error", err.Error()))
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,7 +36,8 @@ type Config struct {
 
 	OllamaProtocol string        `env:"OLLAMA_PROTOCOL" envDefault:"http"`
 	OllamaHost     string        `env:"OLLAMA_HOST" envDefault:"localhost"`
-	OllamaTimeout  time.Duration `env:"OLLAMA_TIMEOUT" envDefault:"15s"` // Timeout for Ollama requests in seconds
+	OllamaModel    string        `env:"OLLAMA_MODEL" envDefault:"llama3.1:8b"` // Model to use for Ollama
+	OllamaTimeout  time.Duration `env:"OLLAMA_TIMEOUT" envDefault:"15s"`       // Timeout for Ollama requests in seconds
 
 	DragonflyAddress        string        `env:"DRAGONFLY_ADDRESS" envDefault:"localhost:6379"`
 	DragonflyPassword       string        `env:"DRAGONFLY_PASSWORD"`

--- a/internal/ollama/ollama.go
+++ b/internal/ollama/ollama.go
@@ -12,10 +12,11 @@ import (
 
 type OllamaClient struct {
 	client *ollama.Client
+	model  string
 }
 
-func NewOllamaClient(baseUrl *url.URL, httpClient *http.Client) (*OllamaClient, error) {
-	return &OllamaClient{client: ollama.NewClient(baseUrl, httpClient)}, nil
+func NewOllamaClient(baseUrl *url.URL, httpClient *http.Client, model string) (*OllamaClient, error) {
+	return &OllamaClient{client: ollama.NewClient(baseUrl, httpClient), model: model}, nil
 }
 
 type DispatchMessage struct {
@@ -43,7 +44,7 @@ var DispatchMessageResponseFormat = json.RawMessage(`{
 func (oc *OllamaClient) ParseRelevantInformationFromDispatchMessage(transcription string) (*DispatchMessage, error) {
 	ctx := context.Background()
 	req := &ollama.GenerateRequest{
-		Model: "llama3.1:8b",
+		Model: oc.model,
 		System: `You are a tool to accurately parse relevant information from a transcription of Fire Department radio messages.
 			You will need to extract the call type and the tactical channel (TAC) from the transcription.
 			Please return the information in the JSON format defined below.


### PR DESCRIPTION
- **fix: mvp**
- **fix: small tweaks**
- **fix: mvp**
- **fix: update test**
- **ci: bump golangci-lint version**
- **chore: disable yamllint line length for docker-compose**
- **fix: handle errors for deferred closes**
- **fix: add a bunch of debug statements**
- **fix: actually add default timeouts**
- **fix: another attempt**
- **fix: pass bytes instead of closer, it ends up getting cancelled**
- **fix: remove bad print statement**
- **fix: move around context for low volume times of night**
- **fix: move nack up higher and split out a little more**
- **fix: add prompt modification to reduce false positives**
- **fix: pulsar client slog logging**
- **fix: use generate endpoint instead of chat to prevent latent requests from storing history**
- **fix: update not trail rescue log message**
- **fix: allow ollama model to be configurable**
