### PR TITLE
fix(openai): resolve $ref into $defs when applying call_type enum

### DIFF
--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -192,7 +192,10 @@ func (oc *OpenAIClient) buildSchema() (*jsonschema.Definition, error) {
 	enum = append(enum, oc.allowedCallTypes...)
 	enum = append(enum, unknownCallType)
 
-	// schema.Properties["messages"].Items.Properties["call_type"]
+	// Walk to messages[].call_type. As of go-openai v1.41+, GenerateSchemaForType
+	// emits a `$ref` into a `$defs` table for nested struct types instead of inlining
+	// Properties on Items. Resolve the ref so the enum patches the right node — and
+	// keep the legacy inline path so older library versions still work.
 	messagesProp, ok := schema.Properties["messages"]
 	if !ok {
 		return nil, fmt.Errorf("schema missing expected `messages` property; library shape changed?")
@@ -200,6 +203,23 @@ func (oc *OpenAIClient) buildSchema() (*jsonschema.Definition, error) {
 	if messagesProp.Items == nil {
 		return nil, fmt.Errorf("schema `messages` has no Items definition; library shape changed?")
 	}
+
+	const dispatchMessageRef = "#/$defs/DispatchMessage"
+	if messagesProp.Items.Ref == dispatchMessageRef {
+		def, ok := schema.Defs["DispatchMessage"]
+		if !ok {
+			return nil, fmt.Errorf("schema `$defs.DispatchMessage` not found; library shape changed?")
+		}
+		callType, ok := def.Properties["call_type"]
+		if !ok {
+			return nil, fmt.Errorf("schema `$defs.DispatchMessage.call_type` not found; library shape changed?")
+		}
+		callType.Enum = enum
+		def.Properties["call_type"] = callType
+		schema.Defs["DispatchMessage"] = def
+		return schema, nil
+	}
+
 	callType, ok := messagesProp.Items.Properties["call_type"]
 	if !ok {
 		return nil, fmt.Errorf("schema `messages.call_type` not found; library shape changed?")

--- a/internal/openai/openai_test.go
+++ b/internal/openai/openai_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStripThinkingPrefix(t *testing.T) {
@@ -52,5 +53,40 @@ func TestStripThinkingPrefix(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			assert.Equal(t, c.want, stripThinkingPrefix(c.in))
 		})
+	}
+}
+
+// Regression guard for the schema-walker bug shipped in v1.1.0: as of go-openai v1.41+,
+// GenerateSchemaForType emits a `$ref` into a `$defs` table for nested struct types
+// instead of inlining Properties on Items. The pre-fix walker only checked the inline
+// path and crashed every dispatch parse with "schema `messages.call_type` not found".
+func TestBuildSchema_AppliesEnumAtCallTypeRef(t *testing.T) {
+	allowed := []string{"Rescue - Trail", "Aid Emergency", "Fire - Structure"}
+	oc := &OpenAIClient{allowedCallTypes: allowed}
+
+	schema, err := oc.buildSchema()
+	require.NoError(t, err, "buildSchema must succeed with v1.41+ schema shape (ref + $defs)")
+	require.NotNil(t, schema)
+
+	// The library indirects through $defs; the enum must land on the resolved node.
+	def, ok := schema.Defs["DispatchMessage"]
+	require.True(t, ok, "expected $defs.DispatchMessage to exist on the generated schema")
+	callType, ok := def.Properties["call_type"]
+	require.True(t, ok, "expected $defs.DispatchMessage.call_type")
+
+	want := append([]string{}, allowed...)
+	want = append(want, unknownCallType)
+	assert.Equal(t, want, callType.Enum, "enum must include allowed types plus the Unknown fallback")
+}
+
+func TestBuildSchema_NoAllowedCallTypes_ReturnsUnconstrainedSchema(t *testing.T) {
+	oc := &OpenAIClient{} // empty allowedCallTypes
+	schema, err := oc.buildSchema()
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	if def, ok := schema.Defs["DispatchMessage"]; ok {
+		callType := def.Properties["call_type"]
+		assert.Empty(t, callType.Enum, "no allowed list configured → no enum constraint")
 	}
 }


### PR DESCRIPTION
## Summary

**Production v1.1.0 is failing every Fire Dispatch (1399) event** with the schema-walker error:

```
failed to build JSON schema: schema `messages.call_type` not found; library shape changed?
```

Cascade impact: the failure leaves `dispatch_in_flight` set, so racing TAC events nack-loop until the marker TTL expires (CLAUDE.md invariant #2 territory). Live logs from the v1.1.0 pod confirm — every 1399 transcription is followed immediately by this error, and TAC events for active talkgroups (1963, 1965) flood ERROR with "rejected during in-flight dispatch".

## Root cause

As of `github.com/sashabaranov/go-openai v1.41+`, `GenerateSchemaForType` emits a `$ref` into a `$defs` table for nested struct types instead of inlining `Properties` on `Items`:

```json
{
  "properties": {
    "messages": { "items": { "$ref": "#/$defs/DispatchMessage" } }
  },
  "$defs": {
    "DispatchMessage": { "properties": { "call_type": { "type": "string" } } }
  }
}
```

The walker in `buildSchema` only checked the inline path (`schema.Properties["messages"].Items.Properties["call_type"]`), which is empty under the new shape — so the enum-injection path errored out 100% of the time, taking dispatch parsing with it.

## Fix

When `messages.Items.Ref == "#/$defs/DispatchMessage"`, resolve through `schema.Defs` to patch the enum on the right node. Kept the legacy inline path as a fallback so older library versions still work.

Added regression tests:
- `TestBuildSchema_AppliesEnumAtCallTypeRef` — asserts the enum lands on the resolved `$defs.DispatchMessage.call_type` node when `allowedCallTypes` is populated.
- `TestBuildSchema_NoAllowedCallTypes_ReturnsUnconstrainedSchema` — asserts no constraint applied when the list is empty (covers the no-call-types-configured deployment).

`buildSchema` was previously untested — this regression slipped through CI as a result.

## Operator note (separate issue)

The other repeating ERROR in production is the DLQ producer failing to create `public/transcribe/file-queue-dlq` — the topic just doesn't exist on the cluster's Pulsar. That's unrelated to this fix; resolve it by either:

```bash
pulsar-admin topics create-partitioned-topic public/transcribe/file-queue-dlq -p 1
```

or setting `PULSAR_DLQ_TOPIC: ""` in the ConfigMap to fall back to infinite redelivery.

## Test plan

- [ ] `go test ./internal/openai/...` green (already verified locally — both new tests pass).
- [ ] After merge + image rollout, watch a 1399 event in the live pod — expected log sequence:
  - `INFO trail rescue call detected call_type="..." tac_channel=...`
  - or `WARN call is not a trail rescue call_type=...`
  - **NOT** `failed to build JSON schema: schema 'messages.call_type' not found`.

Conventional commit `fix:` → semantic-release tags as **v1.1.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)