### PR TITLE
fix(transcribe): clear dispatch_in_flight marker on processRecord exit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,42 +61,50 @@ Each was discovered (and fixed) during development; comments in code reference t
    `WorkerTimeout` window then nack-loops chasing an allow-list write that won't happen.
    (`processRecord`)
 
-3. **Sweeper sidecar cleanup MUST run AFTER `postChannelClosed`, not before** — otherwise
+3. **`dispatch_in_flight` marker MUST be cleared on processRecord exit** — a deferred
+   `Del` runs immediately after the `Set`, so success, error, non-rescue, and panic paths
+   all reach it. Without the defer, a 1399 dispatch that the LLM classifies as anything
+   other than a trail rescue (Smoke - Burn Complaint, Aid Emergency, etc.) leaves the
+   marker set for the full `WorkerTimeout` window — every concurrent TAC transmission
+   nacks-for-retry against a phantom dispatch and eventually DLQs. The TTL is a safety
+   net; the deferred `Del` is authoritative. (`processRecord`)
+
+4. **Sweeper sidecar cleanup MUST run AFTER `postChannelClosed`, not before** — otherwise
    `summary_data:<TGID>` is deleted before `buildFeedbackURL` reads it, and the feedback
    form silently loses the headline + situation_summary prefill. The cleanup uses an
    inline `cleanup()` closure called explicitly on every exit path. (`sweepOnce` in
    `sweeper.go`)
 
-4. **`IsObjectAllowed` returns the parsed key on rejection** — the nack-recovery error
+5. **`IsObjectAllowed` returns the parsed key on rejection** — the nack-recovery error
    message in `processRecord` reads `parsedKey.dk.Talkgroup`. If `IsObjectAllowed` returns
    nil parsed-key, this nil-derefs. (`rules.go`)
 
-5. **Cancel / Switch / sweeper close MUST clean up ALL sidecars**: `tac_meta:<TGID>`,
+6. **Cancel / Switch / sweeper close MUST clean up ALL sidecars**: `tac_meta:<TGID>`,
    `tac_transcripts:<TGID>`, `summary_ts:<TGID>`, `summary_lock:<TGID>`,
    `summary_stale:<TGID>`, `summary_data:<TGID>`, `tg:<TGID>`, plus SREM from
    `allowed_talkgroups` and ZREM from `active_tacs`. Missing one = a closed-then-reopened
    rescue inherits stale state from the prior incident. (`sweeper.go`, `slackctl/cancel.go`,
    `slackctl/switch_tac.go`)
 
-6. **`WorkerTimeout >= OpenAITimeout`** — the worker context wraps the LLM round-trip;
+7. **`WorkerTimeout >= OpenAITimeout`** — the worker context wraps the LLM round-trip;
    if it cancels first, the LLM call gets canceled before it can answer. Currently 180s vs
    120s in `.env`. (`internal/config/config.go`)
 
-7. **`time.Local` override happens BEFORE any time-formatting code runs** — set in
+8. **`time.Local` override happens BEFORE any time-formatting code runs** — set in
    `main.go` immediately after config + slog are wired. Tests that depend on display
    format set `time.Local` themselves (see `slack_test.go`). The binary embeds Go's
    tzdata via `_ "time/tzdata"` import so distroless-static can resolve any IANA zone.
 
-8. **URL buttons in Slack still fire `block_actions` events** — they need a no-op case in
+9. **URL buttons in Slack still fire `block_actions` events** — they need a no-op case in
    the controller dispatch (`ActionIDFeedbackForm`) or the dispatch logs a noisy
    `unknown action_id` WARN on every click. (`internal/slackctl/controller.go`)
 
-9. **The ASR response field is `text`, not `transcription`** — the cluster ASR returns
-   `{"text": "..."}` while the old mock returned `{"transcription": "..."}`. The struct in
-   `internal/asr/client.go` uses `json:"text"`. If you ever swap ASR backends, this is
-   the first thing to check.
+10. **The ASR response field is `text`, not `transcription`** — the cluster ASR returns
+    `{"text": "..."}` while the old mock returned `{"transcription": "..."}`. The struct in
+    `internal/asr/client.go` uses `json:"text"`. If you ever swap ASR backends, this is
+    the first thing to check.
 
-10. **`SLACK_ALLOWED_USER_IDS=*` short-circuits the leadership gate** — the empty-list
+11. **`SLACK_ALLOWED_USER_IDS=*` short-circuits the leadership gate** — the empty-list
     behavior is "deny all" (safe default); `*` is "allow all" (intentional choice, logged
     at WARN). Don't accidentally make empty-list mean "allow all". (`slackctl/controller.go`)
 

--- a/internal/transcribe/integration_test.go
+++ b/internal/transcribe/integration_test.go
@@ -814,17 +814,22 @@ func (s *DispatchSuite) TestProcessRecord_DispatchDedupHit_DoesNotSetInFlightMar
 	slackMock.AssertNotCalled(s.T(), "SendMessageContext", mock.Anything, mock.Anything, mock.Anything)
 }
 
-// FIX (dispatch-in-flight nack recovery): processing a Fire Dispatch event must set the
-// in-flight marker before any other work, so concurrent TAC events can read it and recover.
-func (s *DispatchSuite) TestProcessRecord_DispatchEventSetsInFlightMarker() {
+// FIX (dispatch_in_flight cleanup): processRecord defers a clear of the marker so it
+// is always cleaned up after the dispatch path completes, regardless of outcome. This
+// pins the regression where a non-rescue dispatch (e.g. the LLM classifies as
+// "Smoke - Burn Complaint") left the marker set for the full WorkerTimeout window,
+// causing every concurrent TAC transmission to nack-loop chasing an allow-list write
+// that was never going to happen.
+//
+// The test exercises the panic-during-S3-fetch path (nil s3Client). Defers fire during
+// panic unwind, so the marker should be cleared even though processRecord didn't return
+// cleanly — that's the same property that protects us against unexpected panics in
+// production code paths.
+func (s *DispatchSuite) TestProcessRecord_DispatchPath_ClearsInFlightOnExit() {
 	slackMock := new(mockSlackPoster)
 	mlMock := new(mockMLClient)
 	tc := s.newClientUnderTest(slackMock, mlMock)
 
-	// Mock the rest of the dispatch path so processRecord can reach the end without
-	// genuinely fetching/transcribing. The S3 client is nil in the test client, so we don't
-	// pretend to make an S3 call work — instead we'll only reach the marker-set step before
-	// the S3 fetch fails. That's enough to verify the marker is set.
 	record := &s3event.EventRecord{
 		EventName: s3event.EventObjectCreatedPut,
 		S3: s3event.EventS3Data{
@@ -832,21 +837,18 @@ func (s *DispatchSuite) TestProcessRecord_DispatchEventSetsInFlightMarker() {
 		},
 	}
 
-	// Fire processRecord — it will set the marker, then fail at the S3 fetch (because the
-	// test client has nil s3Client). We don't care about the failure; we only assert the
-	// marker is set as a side-effect of the early dispatch path.
-	defer func() {
-		// recover from the nil-deref panic at S3 fetch — the call sequence is
-		// processRecord → tc.s3Client.GetFile, which panics on a nil s3Client. Catching
-		// the panic lets us assert state without standing up a real S3 mock just for this.
-		_ = recover()
+	// processRecord sets the marker, then panics at the nil s3Client. The deferred clear
+	// in processRecord runs during panic unwind; we recover here to assert post-state.
+	func() {
+		defer func() { _ = recover() }()
+		_ = tc.processRecord(s.ctx, record)
 	}()
-	_ = tc.processRecord(s.ctx, record)
 
-	val, err := s.rdb.Get(s.ctx, dispatchInFlightKey).Result()
-	s.Require().NoError(err, "dispatch_in_flight key must be set after a 1399 event reaches processRecord")
-	s.Equal("1", val)
+	exists, err := s.rdb.Exists(s.ctx, dispatchInFlightKey).Result()
+	s.Require().NoError(err)
+	s.EqualValues(0, exists, "dispatch_in_flight must be cleared by processRecord's defer, even on panic-unwind")
 }
+
 
 // ============================================================================
 // handleMessage: 3 cases (uses the Pulsar container for real ack/nack lifecycle)

--- a/internal/transcribe/transcribe.go
+++ b/internal/transcribe/transcribe.go
@@ -240,6 +240,18 @@ func (tc *TranscribeClient) processRecord(ctx context.Context, record *s3event.E
 		if err := tc.dragonflyClient.Set(ctx, dispatchInFlightKey, tc.config.WorkerTimeout, "1"); err != nil {
 			slog.Warn("failed to set dispatch_in_flight marker; racing TAC events will not recover", slog.String("error", err.Error()))
 		}
+		// FIX (dispatch_in_flight cleanup): clear the marker on exit — success, error,
+		// non-rescue, or panic. Without this, a non-rescue dispatch (e.g. the LLM classifies
+		// as "Smoke - Burn Complaint" or any other non-trail-rescue type) leaves the marker
+		// set for the full WorkerTimeout window with no allow-list write coming. Every TAC
+		// transmission during that window then nacks-for-retry chasing a recovery that
+		// never happens, eventually DLQ'ing them all. The TTL is a safety net only — the
+		// authoritative clear is here.
+		defer func() {
+			if err := tc.dragonflyClient.Del(ctx, dispatchInFlightKey); err != nil {
+				slog.Warn("failed to clear dispatch_in_flight marker", slog.String("error", err.Error()))
+			}
+		}()
 	}
 
 	fileBytes, err := tc.s3Client.GetFile(ctx, key)


### PR DESCRIPTION
## Summary
- A 1399 dispatch that the LLM classified as a non-rescue (e.g. `Smoke - Burn Complaint`) used to leave the `dispatch_in_flight` marker set for the full `WorkerTimeout` window with no allow-list write coming. Concurrent TAC traffic then nack-looped against a phantom dispatch and eventually DLQ'd.
- Symptom from k8s logs: repeated `rejected during in-flight dispatch (talkgroup=1963/1965); nacking for Pulsar redelivery` after a `call is not a trail rescue` log line.
- Fix: defer a `Del` of the marker immediately after the `Set` in `processRecord`, so success / error / non-rescue / panic-unwind paths all clean up. The TTL is now a safety net only; the deferred clear is authoritative.
- Adds a new CLAUDE.md invariant (#3) documenting the cleanup contract, renumbers subsequent invariants.
- Replaces `TestProcessRecord_DispatchEventSetsInFlightMarker` (which encoded the buggy "marker survives exit" behavior) with `TestProcessRecord_DispatchPath_ClearsInFlightOnExit`. The two existing tests around the in-flight protection (`TACWhileDispatchInFlight`, `DispatchDedupHit`) still pin the other halves of the lifecycle.

## Test plan
- [x] `go test -count=1 -timeout 5m ./...` — all green
- [x] Targeted: `go test -count=1 -run 'TestDispatchSuite/TestProcessRecord' ./internal/transcribe/...`
- [ ] Verify in cluster after merge: a non-rescue dispatch (Smoke / Aid / Investigate) no longer triggers a wave of `rejected during in-flight dispatch` errors on subsequent TAC traffic.