### PR TITLE
feat(slackctl): add Close button that ends rescue via the auto-expiry path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,11 +135,12 @@ visible at both layers).
 
 ## Slack interactivity model
 
-Three buttons + one URL button on every rescue alert (when `SLACK_APP_TOKEN` is configured):
+Four buttons + one URL button on every rescue alert (when `SLACK_APP_TOKEN` is configured):
 
 | Action ID | Type | Authorized? | Effect |
 |---|---|---|---|
-| `rescue_cancel` | Button (danger) + confirm | Yes (allowlist) | SREM allow-list, DEL all sidecars, post cancellation reply, chat.update alert to "Cancelled" |
+| `rescue_cancel` | Button (danger) + confirm | Yes (allowlist) | SREM allow-list, DEL all sidecars, post cancellation reply, chat.update alert to "Cancelled" — wipes summary context |
+| `rescue_close` | Button + confirm | Yes (allowlist) | Early end-of-rescue routed through the **same path as auto-expiry**: SREM allow-list + DEL routing inline (so TAC traffic stops immediately), then ZADD `active_tacs` with score=now-1 so the sweeper claims it on its next tick (~5s) and runs `postChannelClosed` + `updateAlertForClosure` (preserving `summary_data` for the feedback URL prefill) + sidecar cleanup |
 | `rescue_extend` | Button + confirm | Yes (allowlist) | Refresh all per-TGID TTLs to a fresh activation window |
 | `rescue_switch_tac` | Static-select + confirm | Yes (allowlist) | Migrate state from old TGID to new TGID; preserve thread_ts |
 | `feedback_form` | URL button (closed alert only) | n/a | Opens Google Form client-side; controller no-ops the resulting `block_actions` event |

--- a/internal/slackctl/close.go
+++ b/internal/slackctl/close.go
@@ -1,0 +1,91 @@
+package slackctl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/searchandrescuegg/transcribe/internal/transcribe"
+	"github.com/slack-go/slack"
+)
+
+// CloseTAC ends the rescue early but routes the closure through the same path the auto-
+// expiry sweeper takes. Distinct from CancelTAC (false-alarm), which wipes the alert and
+// summary context. Close preserves the structured Live Interpretation, rewrites the
+// parent alert with the Submit Feedback button, and posts a normal "Channel Closed"
+// reply — identical to a natural expiry.
+//
+// Effects, in order:
+//  1. Read closure metadata for the TGID; ok=false (no error) when no longer active.
+//  2. SREM the TGID from allowed_talkgroups so further TAC traffic is rejected
+//     immediately rather than waiting for the per-member SADDEX TTL to lapse.
+//  3. DEL tg:<TGID> for the same reason — defensive routing cutoff.
+//  4. ZADD active_tacs with score = now-1 so the sweeper claims it on its next tick
+//     (~5s) and runs postChannelClosed + updateAlertForClosure + sidecar cleanup.
+//
+// We deliberately do NOT touch tac_meta, tac_transcripts, summary_*, or call ZRem on
+// active_tacs — the sweeper owns those deletions, and clearing summary_data prematurely
+// would silently strip the feedback URL prefill (same hazard as invariant #4 in CLAUDE.md).
+func (c *Controller) CloseTAC(ctx context.Context, tgid string) (meta transcribe.ClosureMeta, ok bool, err error) {
+	if tgid == "" {
+		return transcribe.ClosureMeta{}, false, errors.New("CloseTAC: TGID is required")
+	}
+	meta, found, err := c.readClosureMeta(ctx, tgid)
+	if err != nil {
+		return transcribe.ClosureMeta{}, false, err
+	}
+	if !found {
+		return transcribe.ClosureMeta{}, false, nil
+	}
+
+	if err := c.dfly.SRem(ctx, allowedTalkgroupsKey, tgid); err != nil {
+		return meta, false, fmt.Errorf("SRem allowed_talkgroups: %w", err)
+	}
+	if err := c.dfly.Del(ctx, fmt.Sprintf(tgRoutingKeyFmt, tgid)); err != nil {
+		return meta, false, fmt.Errorf("del tg:<TGID>: %w", err)
+	}
+	// ZAdd updates the score for an existing member, so the original future-dated entry
+	// is moved into the past and picked up on the next sweeper tick.
+	triggerScore := float64(time.Now().Unix() - 1)
+	if err := c.dfly.ZAdd(ctx, activeTACsKey, triggerScore, tgid); err != nil {
+		return meta, false, fmt.Errorf("ZAdd active_tacs trigger: %w", err)
+	}
+	return meta, true, nil
+}
+
+func (c *Controller) handleClose(ctx context.Context, payload slack.InteractionCallback, action *slack.BlockAction) {
+	tgid := action.Value
+	meta, ok, err := c.CloseTAC(ctx, tgid)
+	if err != nil {
+		slog.Error("slackctl: close state mutation failed", slog.String("error", err.Error()), slog.String("tgid", tgid), slog.String("user", payload.User.ID))
+		c.postEphemeral(payload, ":warning: Close failed; check service logs.")
+		return
+	}
+	if !ok {
+		c.postEphemeral(payload, ":information_source: This TAC monitoring window is no longer active (already cancelled or auto-expired).")
+		return
+	}
+
+	slog.Info("slackctl: closed TAC monitoring early",
+		slog.String("user", payload.User.ID),
+		slog.String("user_name", payload.User.Name),
+		slog.String("tgid", tgid),
+		slog.String("tac_channel", meta.TACChannel),
+	)
+
+	// Brief attribution reply for the audit trail. The sweeper will follow up within
+	// ~TACSweeperInterval with the canonical "Channel Closed" message and rewrite the
+	// parent alert (including the Submit Feedback button).
+	threadMsg := fmt.Sprintf(":white_check_mark: %s monitoring closed by <@%s> at %s.",
+		meta.TACChannel, payload.User.ID, time.Now().Local().Format("15:04 MST"))
+	if _, _, _, err := c.slackClient.SendMessageContext(ctx,
+		c.cfg.SlackChannelID,
+		slack.MsgOptionText(threadMsg, false),
+		slack.MsgOptionTS(meta.ThreadTS),
+		slack.MsgOptionAsUser(true),
+	); err != nil {
+		slog.Error("slackctl: failed to post close thread reply", slog.String("error", err.Error()))
+	}
+}

--- a/internal/slackctl/controller.go
+++ b/internal/slackctl/controller.go
@@ -138,6 +138,8 @@ func (c *Controller) dispatch(evt *socketmode.Event, client *socketmode.Client) 
 		switch action.ActionID {
 		case transcribe.ActionIDRescueCancel:
 			c.handleCancel(ctx, payload, action)
+		case transcribe.ActionIDRescueClose:
+			c.handleClose(ctx, payload, action)
 		case transcribe.ActionIDRescueExtend:
 			c.handleExtend(ctx, payload, action)
 		case transcribe.ActionIDRescueSwitchTAC:

--- a/internal/slackctl/controller_test.go
+++ b/internal/slackctl/controller_test.go
@@ -297,6 +297,63 @@ func TestParseOldTGIDFromBlockID(t *testing.T) {
 }
 
 // ============================================================================
+// CloseTAC
+// ============================================================================
+
+func (s *SlackctlSuite) TestCloseTAC_TriggersSweeperAndPreservesContext() {
+	s.preloadActiveTAC("1389", "TAC1", "ts-rescue-1")
+
+	// Sidecars the sweeper preserves through the close path. summary_data in particular
+	// is read by the feedback URL builder during the parent-alert rewrite — premature
+	// deletion (the way Cancel does it) would silently strip the prefill.
+	s.Require().NoError(s.dfly.Set(s.ctx, fmt.Sprintf(summaryDataKeyFmt, "1389"), 30*time.Minute, `{"headline":"hiker fall","situation_summary":"x"}`))
+	s.Require().NoError(s.dfly.Set(s.ctx, fmt.Sprintf(summaryTSKeyFmt, "1389"), 30*time.Minute, "ts-summary-1"))
+
+	meta, ok, err := s.controller.CloseTAC(s.ctx, "1389")
+	s.Require().NoError(err)
+	s.True(ok)
+	s.Equal("TAC1", meta.TACChannel)
+	s.Equal("ts-rescue-1", meta.ThreadTS)
+
+	// Routing cut off immediately so further TAC traffic doesn't leak through during the
+	// sweeper-tick lag (the per-member SADDEX TTL would otherwise outlive the click).
+	mem, err := s.rdb.SIsMember(s.ctx, allowedTalkgroupsKey, "1389").Result()
+	s.Require().NoError(err)
+	s.False(mem, "1389 must be removed from allowed_talkgroups immediately")
+	exists, err := s.rdb.Exists(s.ctx, fmt.Sprintf(tgRoutingKeyFmt, "1389")).Result()
+	s.Require().NoError(err)
+	s.EqualValues(0, exists, "tg:1389 must be deleted immediately")
+
+	// active_tacs entry now has a past score → sweeper claims it on its next tick.
+	score, err := s.rdb.ZScore(s.ctx, activeTACsKey, "1389").Result()
+	s.Require().NoError(err)
+	s.LessOrEqual(score, float64(time.Now().Unix()), "score must be in the past for the sweeper to claim it")
+
+	// Sidecars MUST survive — sweeper owns these deletions, and the feedback URL builder
+	// reads summary_data:<TGID> when it rewrites the parent alert.
+	exists, err = s.rdb.Exists(s.ctx, fmt.Sprintf(tacMetaKeyFmt, "1389")).Result()
+	s.Require().NoError(err)
+	s.EqualValues(1, exists, "tac_meta:1389 must survive — sweeper reads it to post Channel Closed")
+	exists, err = s.rdb.Exists(s.ctx, fmt.Sprintf(summaryDataKeyFmt, "1389")).Result()
+	s.Require().NoError(err)
+	s.EqualValues(1, exists, "summary_data:1389 must survive — feedback URL builder reads it")
+	exists, err = s.rdb.Exists(s.ctx, fmt.Sprintf(summaryTSKeyFmt, "1389")).Result()
+	s.Require().NoError(err)
+	s.EqualValues(1, exists, "summary_ts:1389 must survive until sweeper cleanup")
+}
+
+func (s *SlackctlSuite) TestCloseTAC_AlreadyExpired_ReturnsNotOk() {
+	_, ok, err := s.controller.CloseTAC(s.ctx, "1389")
+	s.Require().NoError(err)
+	s.False(ok, "no metadata means the TAC is no longer active; caller surfaces 'no longer active'")
+}
+
+func (s *SlackctlSuite) TestCloseTAC_EmptyTGID_ReturnsError() {
+	_, _, err := s.controller.CloseTAC(s.ctx, "")
+	s.Require().Error(err)
+}
+
+// ============================================================================
 // Authorization
 // ============================================================================
 

--- a/internal/transcribe/slack.go
+++ b/internal/transcribe/slack.go
@@ -46,7 +46,13 @@ type RescueTrailBlocksInput struct {
 // Action IDs are the routing keys the slackctl controller dispatches on. Keep these in
 // sync with internal/slackctl/controller.go.
 const (
-	ActionIDRescueCancel    = "rescue_cancel"
+	ActionIDRescueCancel = "rescue_cancel"
+	// ActionIDRescueClose ends the rescue early but routes through the same path the
+	// auto-expiry sweeper takes — distinct from Cancel (false-alarm), which wipes the
+	// alert + summary context. Close preserves the structured Live Interpretation,
+	// rewrites the parent alert with the Submit Feedback button, and posts a normal
+	// "Channel Closed" reply, identical to a natural expiry.
+	ActionIDRescueClose     = "rescue_close"
 	ActionIDRescueExtend    = "rescue_extend"
 	ActionIDRescueSwitchTAC = "rescue_switch_tac"
 	// ActionIDFeedbackForm is the action_id on the URL-style Submit Feedback button.
@@ -216,6 +222,18 @@ func buildRescueActionsBlock(tacChannel, tacTGID string) slack.Block {
 		slack.NewTextBlockObject(slack.PlainTextType, "Keep monitoring", false, false),
 	)
 
+	closeBtn := slack.NewButtonBlockElement(
+		ActionIDRescueClose,
+		tacTGID,
+		slack.NewTextBlockObject(slack.PlainTextType, "Close (End Rescue)", true, false),
+	)
+	closeBtn.Confirm = slack.NewConfirmationBlockObject(
+		slack.NewTextBlockObject(slack.PlainTextType, fmt.Sprintf("Close %s monitoring?", tacChannel), false, false),
+		slack.NewTextBlockObject(slack.PlainTextType, "Ends the rescue early. The Live Interpretation summary, dispatch context, and Submit Feedback button are preserved — same as a natural auto-close.", false, false),
+		slack.NewTextBlockObject(slack.PlainTextType, "Close monitoring", false, false),
+		slack.NewTextBlockObject(slack.PlainTextType, "Keep monitoring", false, false),
+	)
+
 	extendBtn := slack.NewButtonBlockElement(
 		ActionIDRescueExtend,
 		tacTGID,
@@ -232,7 +250,7 @@ func buildRescueActionsBlock(tacChannel, tacTGID string) slack.Block {
 
 	// block_id encodes the active TGID so the switch handler knows what to migrate FROM.
 	blockID := fmt.Sprintf("%s:%s", ActionsBlockIDPrefix, tacTGID)
-	return slack.NewActionBlock(blockID, cancelBtn, extendBtn, switchSelect)
+	return slack.NewActionBlock(blockID, cancelBtn, closeBtn, extendBtn, switchSelect)
 }
 
 // buildSwitchTACSelect returns a static_select populated with TAC1-TAC10. Each option's


### PR DESCRIPTION
## Summary
- New **Close (End Rescue)** button on every active rescue alert, alongside Cancel / Extend / Switch TAC
- Distinct from Cancel (false-alarm — wipes alert + summary): Close routes through the sweeper's normal expiry path, preserving the Live Interpretation summary and producing the Submit Feedback button with `summary_data` prefill intact
- Implementation reuses the existing sweeper machinery via `ZADD active_tacs score=now-1` — zero duplication of `postChannelClosed` / `updateAlertForClosure` / sidecar cleanup logic

## Why a separate button instead of overloading Cancel
Cancel is a false-alarm action: leadership decided this was never a real rescue, so the alert should disappear and the summary context should go with it. Close is the opposite — the rescue happened, but it's wrapping up earlier than the activation window. We want the operational record (summary, dispatch context, feedback button) to stay just like a natural auto-close at minute 30.

## How it works
1. Read `tac_meta:<TGID>`; surface "no longer active" if missing
2. `SREM allowed_talkgroups <TGID>` + `DEL tg:<TGID>` — inline so further TAC traffic stops immediately rather than waiting for the per-member SADDEX TTL to lapse during the sweeper-tick lag
3. `ZADD active_tacs <TGID> score=now-1` — moves the closure into the past
4. Sweeper claims it on its next tick (~5s by default), runs the existing `postChannelClosed` → `updateAlertForClosure` (with feedback URL built from still-alive `summary_data`) → sidecar cleanup

The 5s lag is acceptable UX and means there's exactly one owner of the close-path Slack work (the sweeper), keeping manual-close output identical to natural-expiry output.

## Test plan
- [x] `go build ./...` — clean
- [x] Unit/integration suite passes (`go test ./...` ~16s)
- [x] New `TestCloseTAC_TriggersSweeperAndPreservesContext` verifies allow-list/routing cut off immediately, ZSET score is in the past, and `tac_meta` / `summary_data` / `summary_ts` survive (so the sweeper's feedback URL build sees them)
- [x] `TestCloseTAC_AlreadyExpired_ReturnsNotOk` — graceful "no longer active" path
- [x] `TestCloseTAC_EmptyTGID_ReturnsError` — input validation
- [ ] Manual e2e in a live Slack workspace: trigger a rescue, click Close, confirm parent alert gets the feedback button + Channel Closed reply lands within ~5s + Live Interpretation message stays put