### PR TITLE
fix(transcribe): parse talkgroup from prefixed S3 keys

### DIFF
--- a/internal/transcribe/parse.go
+++ b/internal/transcribe/parse.go
@@ -17,7 +17,20 @@ type DeconstructedKey struct {
 
 // example key: "1183-1750542445_854412500.1-call_1871.wav"
 // components: "<talkgroup>-<timestamp>_<frequency>.<suffix>.<filetype>"
+//
+// FIX (prefixed-key regression): trunk-recorder now uploads objects under a
+// "YYYY/MM/DD/HH/<talkgroup>/" prefix (homelab c5e064d) instead of the bucket root.
+// The parser has always operated on the bare filename — with a prefix present,
+// "<talkgroup>-..." was preceded by the path, so tg[0] became the whole prefix
+// (e.g. "2026/07/05/19/1967/1967") rather than the talkgroup. That parsed without
+// error, so every object silently missed the allow-list (and never matched the
+// FireDispatch1TGID), causing all traffic to be ack-and-dropped. Reduce to the
+// basename first so both the flat and prefixed layouts parse identically.
 func parseKey(key string) (*DeconstructedKey, error) {
+	if idx := strings.LastIndexByte(key, '/'); idx != -1 {
+		key = key[idx+1:]
+	}
+
 	initialParts := strings.Split(key, ".")
 	if len(initialParts) != 3 {
 		return nil, fmt.Errorf("invalid key format: %s", key)

--- a/internal/transcribe/parse_test.go
+++ b/internal/transcribe/parse_test.go
@@ -1,0 +1,56 @@
+package transcribe
+
+import "testing"
+
+// TestParseKeyTalkgroup guards the talkgroup extraction against upload-path drift.
+// The parser must yield the same talkgroup whether the object sits at the bucket root
+// (the original layout) or under a "YYYY/MM/DD/HH/<talkgroup>/" prefix (homelab c5e064d).
+// Before the basename reduction, the prefixed form parsed without error but produced the
+// whole path as the talkgroup, silently ack-and-dropping every object.
+func TestParseKeyTalkgroup(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		wantTalkgroup string
+		wantErr       bool
+	}{
+		{
+			name:          "flat key at bucket root",
+			key:           "1399-1750542445_854412500.1-call_1871.wav",
+			wantTalkgroup: "1399",
+		},
+		{
+			name:          "date/talkgroup-prefixed key",
+			key:           "2026/07/05/19/1967/1967-1783279634_853525000.1-call_66094.wav",
+			wantTalkgroup: "1967",
+		},
+		{
+			name:          "prefixed dispatch key still resolves to dispatch TGID",
+			key:           "2026/07/05/10/1399/1399-1783279634_854412500.0-call_42.wav",
+			wantTalkgroup: FireDispatch1TGID,
+		},
+		{
+			name:    "no dash in filename",
+			key:     "2026/07/05/1399.foo.wav",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseKey(tt.key)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseKey(%q) = %+v, want error", tt.key, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseKey(%q) unexpected error: %v", tt.key, err)
+			}
+			if got.Talkgroup != tt.wantTalkgroup {
+				t.Errorf("parseKey(%q) talkgroup = %q, want %q", tt.key, got.Talkgroup, tt.wantTalkgroup)
+			}
+		})
+	}
+}

--- a/internal/transcribe/rules.go
+++ b/internal/transcribe/rules.go
@@ -3,6 +3,8 @@ package transcribe
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/agnivade/levenshtein"
@@ -19,6 +21,18 @@ func (tc *TranscribeClient) IsObjectAllowed(ctx context.Context, key string) (bo
 	parsedKey, err := parseKey(key)
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to parse key: %w", err)
+	}
+
+	// Canary for key-format drift. A real talkgroup is always numeric; anything else means
+	// the filename didn't parse the way the roster maps expect (e.g. an upload-path prefix
+	// leaking into the talkgroup, as happened when trunk-recorder moved to date/talkgroup
+	// prefixes). Such an object can never match the roster or the allow-list, so it is
+	// ack-and-dropped below at DEBUG — but that drop is otherwise invisible. Surface it at
+	// WARN so a silent, drop-everything regression can't recur unnoticed. Legitimate
+	// off-roster traffic is still numeric and stays silent.
+	if _, convErr := strconv.Atoi(parsedKey.Talkgroup); convErr != nil {
+		slog.Warn("object key parsed to a non-numeric talkgroup; dropping (possible key-format drift)",
+			slog.String("parsed_talkgroup", parsedKey.Talkgroup), slog.String("key", key))
 	}
 
 	talkgroupInfo := talkgroupFromTGID[parsedKey.Talkgroup]


### PR DESCRIPTION
## Problem

`transcribe` appeared to stop working: the pod logged nothing past startup and produced no transcriptions, yet Pulsar showed the `transcribe-consumer` subscription actively **receiving and acking** every message (backlog 0, 0 nacks, 0 redeliveries). It was silently discarding all traffic.

## Root cause

Homelab commit `c5e064d` moved trunk-recorder's S3 objects from the bucket root to a `YYYY/MM/DD/HH/<talkgroup>/` prefix. Real key now:

```
2026/07/05/19/1967/1967-1783279634_853525000.1-call_66094.wav
```

`parseKey` takes everything before the first `-` as the talkgroup, which now swallowed the whole path prefix (`2026/07/05/19/1967/1967` instead of `1967`). The timestamp/frequency section still parsed, so **no error surfaced** — the object just never matched the roster or `FireDispatch1TGID`, fell through to the ack-and-drop path, and that path logs only at `DEBUG` (invisible at `LOG_LEVEL=info`). Because even fire dispatch (`1399`) was mangled, the allow-list was never populated and **all** traffic was dropped.

## Fix

- `parseKey` reduces the key to its basename before parsing, so the flat and prefixed layouts parse identically.
- WARN canary in `IsObjectAllowed` when a key parses to a non-numeric talkgroup (never legitimate) so a future key-format drift can't silently drop everything again. Legit off-roster traffic stays numeric and silent.
- `parseKey` regression tests covering both layouts + the prefixed dispatch key.

`go build`, `go vet`, and the full `internal/transcribe` package tests (incl. integration) pass.

## Deploy

Merge → tag (`v1.1.3`) → Flux bumps the image. No config change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)