### PR TITLE
fix(dataset): retry postgres connect with backoff instead of crashing on the bootstrap race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.69
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.80.2
 	github.com/caarlos0/env/v11 v11.3.1
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/michaelpeterswa/pulpo v1.0.0
@@ -59,7 +60,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.4.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/internal/dataset/dataset_test.go
+++ b/internal/dataset/dataset_test.go
@@ -120,7 +120,7 @@ func TestPingWithBackoff_RespectsCanceledContext(t *testing.T) {
 	// Valid DSN shape, nothing listening on port 1 — PingContext fails fast.
 	db, err := sql.Open("pgx", "postgres://u:p@127.0.0.1:1/db")
 	require.NoError(t, err)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // already cancelled before we start

--- a/internal/dataset/dataset_test.go
+++ b/internal/dataset/dataset_test.go
@@ -2,8 +2,10 @@ package dataset
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/searchandrescuegg/transcribe/internal/ml"
 	"github.com/stretchr/testify/assert"
@@ -110,4 +112,23 @@ func TestRecordingMLClient_Cleanup_RecordsCleanupKind(t *testing.T) {
 	assert.Equal(t, "claude-haiku-4-5", got.Model, "cleanup is recorded under the cleanup model")
 	assert.Contains(t, got.InputText, "norwell hill trail", "input records the built cleanup prompt")
 	assert.NotNil(t, got.Output)
+}
+
+// pingWithBackoff must abort promptly when the context is cancelled (shutdown), not keep retrying
+// for the full pingMaxElapsedTime — otherwise a shutdown mid-startup would hang for minutes.
+func TestPingWithBackoff_RespectsCanceledContext(t *testing.T) {
+	// Valid DSN shape, nothing listening on port 1 — PingContext fails fast.
+	db, err := sql.Open("pgx", "postgres://u:p@127.0.0.1:1/db")
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before we start
+
+	start := time.Now()
+	err = pingWithBackoff(ctx, db)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "unreachable DB with a cancelled ctx must return an error")
+	assert.Less(t, elapsed, 5*time.Second, "must give up promptly on cancelled ctx, not retry for pingMaxElapsedTime")
 }

--- a/internal/dataset/store.go
+++ b/internal/dataset/store.go
@@ -9,9 +9,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx"
 	"github.com/pressly/goose/v3"
 )
+
+// pingMaxElapsedTime bounds how long NewStore retries the initial Postgres connection. The
+// dataset DB (a CloudNativePG cluster) can take up to ~90s to have ready endpoints on a fresh
+// rollout, and dialing its ClusterIP before then fails fast (EPERM under IPVS kube-proxy). We
+// retry across that window; if the DB is still unreachable after this, it's a genuine problem and
+// the error propagates so it surfaces (main exits → CrashLoopBackOff) rather than being hidden.
+const pingMaxElapsedTime = 3 * time.Minute
 
 //go:embed migrations/*.sql
 var embedMigrations embed.FS
@@ -43,9 +51,7 @@ func NewStore(ctx context.Context, dsn string, bufferSize int) (*Store, error) {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}
 
-	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	if err := db.PingContext(pingCtx); err != nil {
+	if err := pingWithBackoff(ctx, db); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping postgres: %w", err)
 	}
@@ -65,6 +71,33 @@ func NewStore(ctx context.Context, dsn string, bufferSize int) (*Store, error) {
 	s.wg.Add(1)
 	go s.run()
 	return s, nil
+}
+
+// pingWithBackoff verifies connectivity with exponential backoff, retrying transient failures
+// (notably the fresh-rollout race where the CNPG Postgres has no ready endpoints yet) instead of
+// failing the whole service on the first blip. Every failed attempt logs a WARN so the retries are
+// visible; it gives up after pingMaxElapsedTime (or when ctx is cancelled), returning the last
+// error so a persistent problem is surfaced rather than silently swallowed.
+func pingWithBackoff(ctx context.Context, db *sql.DB) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 1 * time.Second
+	bo.MaxInterval = 10 * time.Second
+	bo.MaxElapsedTime = pingMaxElapsedTime
+
+	attempt := 0
+	op := func() error {
+		attempt++
+		pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		return db.PingContext(pingCtx)
+	}
+	notify := func(err error, next time.Duration) {
+		slog.Warn("dataset: postgres not reachable yet, retrying",
+			slog.String("error", err.Error()),
+			slog.Int("attempt", attempt),
+			slog.Duration("retry_in", next))
+	}
+	return backoff.RetryNotify(op, backoff.WithContext(bo, ctx), notify)
 }
 
 func runMigrations(db *sql.DB) error {


### PR DESCRIPTION
## Problem (observed in prod on the v1.4.0 rollout)
`dataset.NewStore` is **fatal** in `main.go`, so a transient failure to reach the dataset Postgres at startup takes down the entire rescue pipeline — contradicting the "dataset is best-effort, never blocks the pipeline" design.

On the v1.4.0 deploy the transcribe pod started ~27s **before** its CloudNativePG cluster had ready endpoints. Dialing the `-rw` ClusterIP with zero endpoints failed fast with `connect: operation not permitted` (the IPVS kube-proxy signature — no NetworkPolicy involved), `NewStore` returned the error, and the service **crash-looped ~90s (4 restarts)** until Postgres came up. It self-healed, but any restart during a Postgres blip would take the pipeline down again.

## Fix
Wrap the initial `PingContext` in `cenkalti/backoff/v4` (exponential, `InitialInterval=1s`, `MaxInterval=10s`, `MaxElapsedTime=3m`):
- **Retries absorb the CNPG bootstrap window** so the transient race no longer crash-loops.
- **Every attempt logs a WARN** (`postgres not reachable yet, retrying`) so the retries are visible.
- **Genuine failures still surface** — after the retry budget the error propagates, `main` exits → CrashLoopBackOff, so a real misconfiguration (wrong DSN, DB down) is never silently swallowed. *We still know if there's an issue.*
- **Aborts promptly on context cancellation** (shutdown) — covered by a new unit test (`TestPingWithBackoff_RespectsCanceledContext`).

Migrations and the rest of `NewStore` are unchanged; only the connectivity gate is retried.

## Test
- New unit test verifies cancel-fast behavior (returns in <5s, not the 3m budget).
- `go build`/`vet`/`gofmt` clean; dataset package tests pass.

## Optional follow-up (not in this PR)
Could also add a Postgres `initContainer`/readiness wait in the homelab manifest to avoid the race entirely — but the retry makes that unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)