### PR TITLE
feat(transcribe): dedup same-incident re-pages + add a delete-message button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ button opens a Google Form prefilled with incident context.
 | Additive live-interpretation summary: prev summary fed back as input | Stops key-event churn — the model EXTENDS its prior summary (preserve established KeyEvents, append new) instead of re-deriving from scratch each transmission. Prev summary read from the existing `summary_data` (no new key); missing/garbled prior degrades to the old full-rewrite behavior | `internal/prompts` (summary rule #12 + `renderPreviousSummary`), `ml.RescueSummaryInput.PreviousSummary`, `live_interpretation.go` (`runOneSummaryPass` reads `readSummaryData`) |
 | Per-transmission LLM cleanup of TAC traffic | Raw ASR TAC transmissions were posted verbatim; a dedicated (cheap-model) cleanup call fixes ASR errors, place names (gazetteer), and unit callsigns before the thread reply AND the summary. Best-effort with raw fallback; kill-switch `TAC_CLEANUP_ENABLED` | `internal/ml` (`TranscriptCleaner`), `internal/prompts` (`TACCleanupSystemPrompt`), both backends' `CleanTACTranscript`, `process.go` (`maybeCleanTranscript`) |
 | CAD (PulsePoint) unit enrichment behind an optional resolver | Feeds the units actually assigned to the call into cleanup + summary so garbled callsigns snap to real units. Fuzzy correlation (location + call-type + recency) with agency-roster fallback; entirely best-effort and flag-gated (`PULPO_ENABLED`). Cached per-rescue in `pulpo_units:<TGID>` | `internal/pulsepoint/` (Resolver, `selectUnitContext`, `UnitContext.PromptBlock`), `transcribe.UnitResolver`, `unit_context.go` (`unitContextFor`) |
+| Same-incident dispatch dedup keyed on active `tac_meta:<TGID>` | A TAC is one incident at a time, so a 2nd tone-out naming an already-active TAC is an additional unit, not a new rescue. `processDispatchCall` checks `readClosureMeta` before posting; if active it refreshes the window + posts a thread reply instead of a 2nd alert — which would overwrite `tg:<TGID>` and orphan the original thread. (Residual: near-simultaneous first tone-outs can still double-post; the "different times" case is covered.) | `process.go` (`handleAdditionalDispatch`), `slack.go` (`BuildAdditionalDispatchBlocks`) |
+| Delete button targets the clicked message, not `tac_meta.MessageTS` | Orphaned duplicates share a TGID with the live alert, so a TGID-keyed delete would nuke the live one. `rescue_delete` deletes `payload.Container.MessageTs` and only tears down state when that ts IS the live alert. | `slackctl/delete.go` |
 
 ---
 
@@ -147,7 +149,7 @@ visible at both layers).
 
 ## Slack interactivity model
 
-Four buttons + one URL button on every rescue alert (when `SLACK_APP_TOKEN` is configured):
+Five buttons + one URL button on every rescue alert (when `SLACK_APP_TOKEN` is configured):
 
 | Action ID | Type | Authorized? | Effect |
 |---|---|---|---|
@@ -155,6 +157,7 @@ Four buttons + one URL button on every rescue alert (when `SLACK_APP_TOKEN` is c
 | `rescue_close` | Button + confirm | Yes (allowlist) | Early end-of-rescue routed through the **same path as auto-expiry**: SREM allow-list + DEL routing inline (so TAC traffic stops immediately), then ZADD `active_tacs` with score=now-1 so the sweeper claims it on its next tick (~5s) and runs `postChannelClosed` + `updateAlertForClosure` (preserving `summary_data` for the feedback URL prefill) + sidecar cleanup |
 | `rescue_extend` | Button + confirm | Yes (allowlist) | Refresh all per-TGID TTLs to a fresh activation window |
 | `rescue_switch_tac` | Static-select + confirm | Yes (allowlist) | Migrate state from old TGID to new TGID; preserve thread_ts |
+| `rescue_delete` | Button (danger) + confirm | Yes (allowlist) | chat.delete **the specific clicked message** (`payload.Container.MessageTs`). Smart: if that ts == `tac_meta.MessageTS` it's the live alert → tear the incident down via `CancelTAC` (no tombstone) then delete; otherwise it's an orphan → delete the message only, live incident untouched. (`slackctl/delete.go`) |
 | `feedback_form` | URL button (closed alert only) | n/a | Opens Google Form client-side; controller no-ops the resulting `block_actions` event |
 
 Authorization: `SLACK_ALLOWED_USER_IDS` (comma-separated user IDs). Empty = deny all.

--- a/internal/slackctl/controller.go
+++ b/internal/slackctl/controller.go
@@ -144,6 +144,8 @@ func (c *Controller) dispatch(evt *socketmode.Event, client *socketmode.Client) 
 			c.handleExtend(ctx, payload, action)
 		case transcribe.ActionIDRescueSwitchTAC:
 			c.handleSwitchTAC(ctx, payload, action)
+		case transcribe.ActionIDRescueDelete:
+			c.handleDelete(ctx, payload, action)
 		case transcribe.ActionIDFeedbackForm:
 			// URL buttons fire a block_actions event AND open the link client-side — Slack
 			// sends both. We have nothing to do server-side; this case exists only to

--- a/internal/slackctl/delete.go
+++ b/internal/slackctl/delete.go
@@ -1,0 +1,70 @@
+package slackctl
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/slack-go/slack"
+)
+
+// handleDelete removes the specific alert MESSAGE the Delete button was clicked on. It always
+// targets payload.Container.MessageTs (the clicked message), so an orphaned duplicate can be
+// removed without disturbing the live alert that shares its TGID.
+//
+// Smart teardown: if the clicked message IS the live alert (its ts matches tac_meta.MessageTS),
+// deleting it also tears the incident down via CancelTAC (SREM allow-list + DEL sidecars + ZREM)
+// so a false-positive alert doesn't keep monitoring its TAC in the background. If it's an orphan
+// (ts differs) or the incident is already gone, only the message is removed and any live incident
+// is left untouched.
+func (c *Controller) handleDelete(ctx context.Context, payload slack.InteractionCallback, action *slack.BlockAction) {
+	tgid := action.Value
+	channelID := payload.Container.ChannelID
+	msgTS := payload.Container.MessageTs
+
+	if channelID == "" || msgTS == "" {
+		slog.Warn("slackctl: delete missing message reference",
+			slog.String("tgid", tgid), slog.String("channel", channelID), slog.String("message_ts", msgTS))
+		c.postEphemeral(payload, ":warning: Delete failed — couldn't identify which message to remove.")
+		return
+	}
+
+	// Determine whether this is the live alert. A read error defaults to "not live" so we never
+	// wrongly tear down an incident we couldn't verify — we just remove the clicked message.
+	meta, ok, err := c.readClosureMeta(ctx, tgid)
+	if err != nil {
+		slog.Error("slackctl: delete could not read closure meta; treating as message-only",
+			slog.String("error", err.Error()), slog.String("tgid", tgid))
+		ok = false
+	}
+	isLiveAlert := ok && meta.MessageTS == msgTS
+
+	if isLiveAlert {
+		if _, _, cerr := c.CancelTAC(ctx, tgid); cerr != nil {
+			slog.Error("slackctl: delete teardown failed",
+				slog.String("error", cerr.Error()), slog.String("tgid", tgid), slog.String("user", payload.User.ID))
+			c.postEphemeral(payload, ":warning: Delete failed while stopping monitoring; check service logs.")
+			return
+		}
+	}
+
+	if _, _, derr := c.slackClient.DeleteMessageContext(ctx, channelID, msgTS); derr != nil {
+		slog.Error("slackctl: chat.delete failed",
+			slog.String("error", derr.Error()), slog.String("tgid", tgid), slog.String("message_ts", msgTS))
+		c.postEphemeral(payload, ":warning: Couldn't delete the message (Slack permissions?). Check service logs.")
+		return
+	}
+
+	if isLiveAlert {
+		slog.Info("slackctl: deleted live rescue alert and stopped monitoring",
+			slog.String("user", payload.User.ID), slog.String("user_name", payload.User.Name),
+			slog.String("tgid", tgid), slog.String("tac_channel", meta.TACChannel))
+		c.postEphemeral(payload, fmt.Sprintf(":wastebasket: Deleted the live alert for %s and stopped monitoring.", meta.TACChannel))
+		return
+	}
+
+	slog.Info("slackctl: deleted orphaned/duplicate rescue alert",
+		slog.String("user", payload.User.ID), slog.String("user_name", payload.User.Name),
+		slog.String("tgid", tgid), slog.String("message_ts", msgTS))
+	c.postEphemeral(payload, ":wastebasket: Deleted this alert message. Any live rescue on this channel is unaffected.")
+}

--- a/internal/transcribe/integration_test.go
+++ b/internal/transcribe/integration_test.go
@@ -260,6 +260,52 @@ func (s *DispatchSuite) TestProcessDispatchCall_NoTrailRescue_IsNoOp() {
 	s.EqualValues(0, count)
 }
 
+// A second tone-out for a TAC that already has an active rescue must NOT post a new alert or
+// steal the routing key — it's an additional unit on the same incident. It posts one thread reply
+// to the ORIGINAL thread and refreshes the window.
+func (s *DispatchSuite) TestProcessDispatchCall_AdditionalTone_DedupsToExistingThread() {
+	slackMock := new(mockSlackPoster)
+	mlMock := new(mockMLClient)
+	tc := s.newClientUnderTest(slackMock, mlMock)
+
+	tgid := talkgroupFromRadioShortCode["TAC1"].TGID
+	// Seed an already-active rescue on TAC1 (original alert thread = "orig-thread").
+	meta := ClosureMeta{TGID: tgid, TACChannel: "TAC1", ThreadTS: "orig-thread", SourceTalkgroup: FireDispatch1TGID, MessageTS: "orig-thread", Transcription: "original dispatch"}
+	payload, _ := json.Marshal(meta)
+	s.Require().NoError(tc.dragonflyClient.Set(s.ctx, fmt.Sprintf(tacMetaKeyFmt, tgid), 1*time.Hour, string(payload)))
+	s.Require().NoError(tc.dragonflyClient.Set(s.ctx, fmt.Sprintf(talkgroupKeyPrefix, tgid), 1*time.Hour, "orig-thread"))
+
+	mlMock.On("ParseRelevantInformationFromDispatchMessage", mock.Anything, "raw2").Return(
+		dispatchMessages(ml.DispatchMessage{CallType: "Rescue - Trail", TACChannel: "TAC1", CleanedTranscription: "additional unit"}), nil)
+	// Exactly ONE Slack post — the thread reply. A second (new-alert) post would fail .Once().
+	slackMock.On("SendMessageContext", mock.Anything, "C-TEST", mock.Anything).Return("C-TEST", "reply-ts", "", nil).Once()
+
+	parsed := &AdornedDeconstructedKey{dk: &DeconstructedKey{Talkgroup: FireDispatch1TGID, Time: time.Now()}}
+	err := tc.processDispatchCall(s.ctx, parsed, stubASRResponse("raw2"))
+	s.Require().NoError(err)
+
+	mlMock.AssertExpectations(s.T())
+	slackMock.AssertExpectations(s.T())
+
+	// Routing must still point at the ORIGINAL thread — the re-page did not steal it.
+	thread, err := tc.dragonflyClient.Get(s.ctx, fmt.Sprintf(talkgroupKeyPrefix, tgid))
+	s.Require().NoError(err)
+	s.Equal("orig-thread", thread, "additional tone-out must not overwrite routing to a new thread")
+
+	// tac_meta unchanged (still the original alert message).
+	metaAfter, ok := tc.readClosureMeta(s.ctx, tgid)
+	s.Require().True(ok)
+	s.Equal("orig-thread", metaAfter.MessageTS)
+
+	// Window refreshed: allow-list membership + a pending closure in the ZSET.
+	isMember, err := tc.dragonflyClient.SMisMember(s.ctx, "allowed_talkgroups", tgid)
+	s.Require().NoError(err)
+	s.Equal([]bool{true}, isMember)
+	zcount, err := s.rdb.ZCard(s.ctx, activeTACsKey).Result()
+	s.Require().NoError(err)
+	s.EqualValues(1, zcount)
+}
+
 func (s *DispatchSuite) TestProcessDispatchCall_UnknownTACChannel_ReturnsError() {
 	slackMock := new(mockSlackPoster)
 	mlMock := new(mockMLClient)

--- a/internal/transcribe/process.go
+++ b/internal/transcribe/process.go
@@ -76,6 +76,15 @@ func (tc *TranscribeClient) processDispatchCall(ctx context.Context, parsedKey *
 		return fmt.Errorf("%w: %s", ErrFailedToFindTalkgroup, dispatchMessage.TACChannel)
 	}
 
+	// DEDUP (same-incident re-page): if this TAC already has an active rescue, this tone-out is
+	// an additional unit paged onto the SAME incident — not a new rescue. Posting a fresh alert
+	// here would overwrite the tg:<TGID> routing key, stealing TAC traffic + live interpretation
+	// away from the original thread and orphaning it (with no safe way to act on the old alert).
+	// Instead, refresh the activation window and note the re-page in the existing thread.
+	if meta, active := tc.readClosureMeta(ctx, tg.TGID); active {
+		return tc.handleAdditionalDispatch(ctx, parsedKey, tr, meta)
+	}
+
 	err = tc.dragonflyClient.SAddEx(ctx, "allowed_talkgroups", tc.config.TacticalChannelActivationDuration, tg.TGID)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrFailedToAddTalkgroupToAllowlist, err.Error())
@@ -132,6 +141,43 @@ func (tc *TranscribeClient) processDispatchCall(ctx context.Context, parsedKey *
 		tc.resolveAndCacheUnitContext(ctx, tg.TGID, tr.Transcription, parsedKey.dk.Time)
 	}
 
+	return nil
+}
+
+// handleAdditionalDispatch processes a re-page for an already-active rescue: it refreshes the
+// activation window (a fresh tone-out means the incident is still going) and posts an
+// informational reply in the original rescue thread. It deliberately does NOT post a new alert or
+// touch tg:<TGID> beyond refreshing its TTL, so the original thread keeps ownership of the
+// incident. Best-effort throughout — the per-S3-key dedup guard means this audio won't be
+// reprocessed on redelivery, so we swallow errors (logging them) and ack rather than risk losing
+// the re-page entirely or double-posting the reply.
+func (tc *TranscribeClient) handleAdditionalDispatch(ctx context.Context, parsedKey *AdornedDeconstructedKey, tr *asr.TranscriptionResponse, meta ClosureMeta) error {
+	slog.Info("additional dispatch for an active rescue; deduping (no new alert)",
+		slog.String("tgid", meta.TGID), slog.String("tac_channel", meta.TACChannel), slog.String("thread", meta.ThreadTS))
+
+	expiresAt := time.Now().Add(tc.config.TacticalChannelActivationDuration).Local()
+
+	// Refresh the activation window: allow-list membership, routing TTL, and the auto-close.
+	if err := tc.dragonflyClient.SAddEx(ctx, "allowed_talkgroups", tc.config.TacticalChannelActivationDuration, meta.TGID); err != nil {
+		slog.Error("additional dispatch: failed to refresh allow-list", slog.String("error", err.Error()), slog.String("tgid", meta.TGID))
+	}
+	if err := tc.dragonflyClient.Set(ctx, fmt.Sprintf(talkgroupKeyPrefix, meta.TGID), tc.config.TacticalChannelActivationDuration, meta.ThreadTS); err != nil {
+		slog.Error("additional dispatch: failed to refresh routing key", slog.String("error", err.Error()), slog.String("tgid", meta.TGID))
+	}
+	// Reuse the ORIGINAL meta (thread_ts, message_ts, dispatch transcript) with the new expiry so
+	// the auto-close pushes out and the feedback prefill still reflects the initiating dispatch.
+	if err := tc.ScheduleTACClosure(ctx, meta, expiresAt); err != nil {
+		slog.Error("additional dispatch: failed to reschedule closure", slog.String("error", err.Error()), slog.String("tgid", meta.TGID))
+	}
+
+	// Note the re-page in the original thread so operators see the additional unit.
+	if _, err := tc.sendSlackWithRetry(ctx, parsedKey.dk.Talkgroup,
+		slack.MsgOptionBlocks(BuildAdditionalDispatchBlocks(meta.TACChannel, tr.Transcription, parsedKey.dk.Time)...),
+		slack.MsgOptionTS(meta.ThreadTS),
+		slack.MsgOptionAsUser(true),
+	); err != nil {
+		slog.Error("additional dispatch: failed to post thread reply", slog.String("error", err.Error()), slog.String("tgid", meta.TGID))
+	}
 	return nil
 }
 

--- a/internal/transcribe/slack.go
+++ b/internal/transcribe/slack.go
@@ -59,6 +59,11 @@ const (
 	ActionIDRescueClose     = "rescue_close"
 	ActionIDRescueExtend    = "rescue_extend"
 	ActionIDRescueSwitchTAC = "rescue_switch_tac"
+	// ActionIDRescueDelete permanently removes the specific alert MESSAGE it was clicked on
+	// (chat.delete). If that message is the live alert it also tears the incident down (like
+	// Cancel, minus the tombstone); if it's an orphaned duplicate it only removes the message and
+	// leaves the live incident alone. Distinct from Cancel/Close, which leave a message behind.
+	ActionIDRescueDelete = "rescue_delete"
 	// ActionIDFeedbackForm is the action_id on the URL-style Submit Feedback button.
 	// Slack sends a block_actions event for URL buttons too (so engagement is trackable),
 	// but we have nothing server-side to do — the controller's switch handles it as a
@@ -269,9 +274,26 @@ func buildRescueActionsBlock(tacChannel, tacTGID string) slack.Block {
 
 	switchSelect := buildSwitchTACSelect(tacChannel)
 
+	// Delete: removes THIS alert message. Danger-styled + confirm because it's destructive and,
+	// on the live alert, also stops monitoring. The confirm can't know at render time whether the
+	// clicked message is the live alert or an orphaned duplicate, so it warns about both.
+	deleteBtn := slack.NewButtonBlockElement(
+		ActionIDRescueDelete,
+		tacTGID,
+		slack.NewTextBlockObject(slack.PlainTextType, "Delete message", true, false),
+	)
+	deleteBtn.Style = slack.StyleDanger
+	deleteBtn.Confirm = slack.NewConfirmationBlockObject(
+		slack.NewTextBlockObject(slack.PlainTextType, "Delete this alert message?", false, false),
+		slack.NewTextBlockObject(slack.PlainTextType,
+			"Permanently removes this message. If it's the live alert, this also STOPS monitoring for this rescue (allow-list + context cleared) — use Cancel/Close if you want a record left behind. If it's a duplicate/orphaned alert, only this message is removed. This cannot be undone.", false, false),
+		slack.NewTextBlockObject(slack.PlainTextType, "Delete message", false, false),
+		slack.NewTextBlockObject(slack.PlainTextType, "Keep it", false, false),
+	)
+
 	// block_id encodes the active TGID so the switch handler knows what to migrate FROM.
 	blockID := fmt.Sprintf("%s:%s", ActionsBlockIDPrefix, tacTGID)
-	return slack.NewActionBlock(blockID, cancelBtn, closeBtn, extendBtn, switchSelect)
+	return slack.NewActionBlock(blockID, cancelBtn, closeBtn, extendBtn, switchSelect, deleteBtn)
 }
 
 // buildSwitchTACSelect returns a static_select populated with TAC1-TAC10. Each option's
@@ -307,6 +329,32 @@ func buildSwitchTACSelect(currentTACChannel string) *slack.SelectBlockElement {
 		slack.NewTextBlockObject(slack.PlainTextType, "Keep current", false, false),
 	)
 	return sel
+}
+
+// BuildAdditionalDispatchBlocks renders the thread reply posted when a re-page (an additional
+// unit toned out) is deduped onto an already-active rescue. It lives in the original rescue
+// thread so operators see the extra dispatch without a second top-level alert.
+func BuildAdditionalDispatchBlocks(tacChannel, transcription string, at time.Time) []slack.Block {
+	return []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType,
+				fmt.Sprintf(":bell: *Additional dispatch* — another unit was toned out for this incident (%s) at %s.",
+					tacChannel, at.Local().Format("15:04 MST")),
+				false, false),
+			nil, nil,
+		),
+		slack.NewRichTextBlock(
+			"",
+			&slack.RichTextPreformatted{
+				RichTextSection: slack.RichTextSection{
+					Type:     slack.RTEPreformatted,
+					Elements: []slack.RichTextSectionElement{slack.NewRichTextSectionTextElement(transcription, nil)},
+				},
+				Border: 0,
+			},
+		),
+		slack.NewDividerBlock(),
+	}
 }
 
 type ThreadCommunicationBlocksInput struct {

--- a/internal/transcribe/slack_sar_test.go
+++ b/internal/transcribe/slack_sar_test.go
@@ -55,6 +55,15 @@ func TestBuildRescueTrailBlocks_SARNotifiedBadge(t *testing.T) {
 	})
 }
 
+func TestBuildAdditionalDispatchBlocks(t *testing.T) {
+	blocks := transcribe.BuildAdditionalDispatchBlocks(
+		"TAC8", "Rescue Trail TAC 8 additional engine 171", time.Date(2026, 7, 15, 14, 30, 0, 0, time.UTC))
+	got := marshalBlocks(t, blocks)
+	assert.Contains(t, got, "Additional dispatch", "reply must flag it as an additional dispatch, not a new rescue")
+	assert.Contains(t, got, "TAC8")
+	assert.Contains(t, got, "additional engine 171", "reply carries the re-page transcription")
+}
+
 func TestBuildLiveInterpretationBlocks_SARNotifiedBadge(t *testing.T) {
 	updated := time.Date(2026, 7, 9, 10, 15, 0, 0, time.UTC)
 


### PR DESCRIPTION
Fixes two related operator pain points around multi-unit incidents.

## Problem
When multiple units page out for the **same incident at different times**, each 1399 tone-out ran `processDispatchCall` independently → posted a **new** rescue alert and **overwrote** the `tg:<TGID>` routing key. So TAC traffic + live interpretation only followed the newest thread, and the earlier alerts orphaned — and you couldn't safely act on them, because their Cancel/Delete buttons operate on the shared TGID (i.e. the *live* incident).

## Fix — two parts

**1. Same-incident dedup.** A TAC is one incident at a time, so a second tone-out naming an already-active TAC is an *additional unit*, not a new rescue. `processDispatchCall` now checks `readClosureMeta` before posting; if the TAC is already active it:
- refreshes the activation window (allow-list + routing TTL + auto-close), and
- posts one informational reply in the **original** thread (`:bell: Additional dispatch …`) via `BuildAdditionalDispatchBlocks`,

instead of a second top-level alert that would steal the routing. *(Residual: near-simultaneous first tone-outs can still double-post; the "different times" case — the reported one — is covered.)*

**2. Delete-message button** (`rescue_delete`, danger + confirm). Removes the **specific clicked message** (`payload.Container.MessageTs`), so an orphaned duplicate can be deleted without disturbing the live alert that shares its TGID. **Smart teardown:** if the clicked message *is* the live alert (ts matches `tac_meta.MessageTS`), deleting it also tears the incident down (`CancelTAC`, no "Cancelled" tombstone); if it's an orphan, only the message is removed and any live incident is left running. The confirm dialog warns about both outcomes.

## Tests
- `TestProcessDispatchCall_AdditionalTone_DedupsToExistingThread` — asserts exactly one Slack post (the thread reply, not a new alert), routing preserved on the original thread, `tac_meta` unchanged, window refreshed.
- `TestBuildAdditionalDispatchBlocks` — reply flags "Additional dispatch" + carries the transcription.
- Full transcribe + slackctl suites green; `go build`/`vet`/`gofmt` clean.

## Notes
- No Slack manifest change — buttons are runtime message blocks; the bot already has `chat:write` (deletes its own messages).
- Independent of the dataset-backoff fix (#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)